### PR TITLE
feat/updates

### DIFF
--- a/kubernetes-cluster/gcp/main.tf
+++ b/kubernetes-cluster/gcp/main.tf
@@ -1,7 +1,7 @@
 
 variable "kubernetes_cluster_configurations" {}
 module "captain" {
-  source         = "git::https://github.com/GlueOps/terraform-module-cloud-gcp-kubernetes-cluster.git?ref=v0.3.1"
+  source         = "git::https://github.com/GlueOps/terraform-module-cloud-gcp-kubernetes-cluster.git?ref=v0.4.0"
   network_ranges = var.kubernetes_cluster_configurations.network_ranges
   project_id     = var.kubernetes_cluster_configurations.project_id
   region         = var.kubernetes_cluster_configurations.region


### PR DESCRIPTION
- feat: update gcp terraform to v0.4.0 which has a bigger node size
- feat: update glueops-platform to v0.24.1 which includes new alerts and fixes for existing alerts
